### PR TITLE
Add new openai and anthropic models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Reright",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "Reright",
-      "version": "0.3.0",
+      "version": "0.4.1",
       "dependencies": {
         "@babel/preset-react": "^7.28.5",
         "@babel/preset-typescript": "^7.28.5",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Reright"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "core-foundation 0.9.4",
  "log",

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -27,20 +27,30 @@ export const providerModels = {
   openai: [
     "gpt-4o-mini",
     "gpt-4.1-nano",
+    "gpt-4.1",
     "gpt-5-nano",
     "gpt-5-mini",
-    "gpt-5.2",
     "gpt-5",
-    "gpt-4.1"
+    "gpt-5.2",
+    "gpt-5.4-nano",
+    "gpt-5.4-mini",
+    "gpt-5.4",
+    "gpt-5.5"
   ],
-  anthropic: ["claude-haiku-4-5", "claude-sonnet-4-5", "claude-opus-4-5"],
+  anthropic: [
+    "claude-haiku-4-5",
+    "claude-sonnet-4-5",
+    "claude-sonnet-4-6",
+    "claude-opus-4-5",
+    "claude-opus-4-7"
+  ],
   ["google-genai"]: ["gemini-flash-lite-latest", "gemini-flash-latest"]
 } as Record<string, string[]>;
 
 export const recommendedModels = [
-  "gpt-4o-mini",
-  "gpt-5.2",
-  "claude-haiku-4-5",
+  "gpt-5.4-mini",
+  "gpt-5.5",
+  "claude-sonnet-4-6",
   "gemini-flash-lite-latest"
 ];
 

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -81,7 +81,7 @@ const defaultSettings: Settings = {
   ],
   commandSeparator: "///",
   model: {
-    modelId: "gpt-5.2",
+    modelId: "gpt-5.4-mini",
     provider: "openai",
     apiKey: ""
   },

--- a/src/ui/screens/settings.tsx
+++ b/src/ui/screens/settings.tsx
@@ -111,7 +111,7 @@ const createSettingsSchema = (
             hint: t(translationKeys.screens.settings.form.model.modelId.hint),
             options: providerModels[selectedProvider].map((model) => ({
               label: `${model}${
-                recommendedModels.includes(model) ? " ⚡" : ""
+                recommendedModels.includes(model) ? " 👌" : ""
               }`,
               value: model
             }))


### PR DESCRIPTION
- Adds the GPT-5.4 family (`nano`, `mini`, base) and `gpt-5.5` to the OpenAI list
- Adds `claude-sonnet-4-6` and `claude-opus-4-7` to the Anthropic list
- Updates the recommended models and bumps the default to `gpt-5.4-mini`
- Switches the recommended-model indicator emoji from ⚡ to 👌

