### PR TITLE
Fix rewrite stalling when main window is hidden

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,7 +19,8 @@
         "hiddenTitle": true,
         "titleBarStyle": "Overlay",
         "width": 960,
-        "height": 640
+        "height": 640,
+        "backgroundThrottling": "disabled"
       }
     ],
     "security": {


### PR DESCRIPTION
On macOS, when the main window was closed to the tray, the WKWebView's default `inactiveSchedulingPolicy` (`suspend`) would fully pause the WebView's JavaScript engine after a few seconds of inactivity, including any in-flight `fetch` to the LLM. The rewrite would appear to start (the hourglass icon would show up) but then stall until the user generated activity such as hovering the tray icon, which woke the WebProcess back up. This PR sets `backgroundThrottling: "disabled"` on the main window, which switches the policy to `none` and keeps the WebView running normally even when not in a window.